### PR TITLE
Add Phu Nguyen to July Liftoff

### DIFF
--- a/LEARNERS(07-2018).md
+++ b/LEARNERS(07-2018).md
@@ -161,3 +161,5 @@
 - Joey W
 - [Wood, Jared (@pocolius)](https://github.com/Pocolius/liftoff-assignments)
 - Richard Z
+- Phu N
+- [PHU, NGUYEN (@phucodes)(https://github.com/phucodes/liftoff-assignments)]


### PR DESCRIPTION
Adding Phu Nguyen's section to July 2018 Saint Louis Liftoff.