### PR TITLE
Fixed links for liftoff material

### DIFF
--- a/C1-Online_Profiles/README.md
+++ b/C1-Online_Profiles/README.md
@@ -2,7 +2,7 @@
 For this assignment you will need to upload your resume, and provide links to your GitHub account, and your LinkedIn account.
 
 ## Assignment Description
-[Online Profiles Assignment](https://education.launchcode.org/liftoff/assignments/online-profiles/)
+[Online Profiles Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/online-profiles/)
 
 ## Submission Instructions
  

--- a/C2-Live_Coding/README.md
+++ b/C2-Live_Coding/README.md
@@ -4,7 +4,7 @@ For this assignment you will be going through a live coding session with a Mento
 Your live coding administrator will be grading your ability to demonstrate your problem solving ability, and will expect you to: gather requiremetns, break down problems, logic, code, test, and make changes.
 
 ## Assignment Description
-[Live Coding Assignment](https://education.launchcode.org/liftoff/assignments/live-coding/)
+[Live Coding Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/live-coding/)
 
 ## Submission Instructions
 You are not required to submit anything via GitHub, but you are responsible for ensuring your grade is recorded correctly. Check your grade in Canvas after completing this assignment.

--- a/C3-Mock_Interview/README.md
+++ b/C3-Mock_Interview/README.md
@@ -4,7 +4,7 @@ For this assignment you will be going through a mock interview with a Mentor, Vo
 You interviewer will be grading your ability to answer questions completely, stay on topic, and your ability to include examples from your life to back up your answers.
 
 ## Assignment Description
-[Mock Interview Assignment](https://education.launchcode.org/liftoff/assignments/mock-interview/)
+[Mock Interview Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/mock-interview/)
 
 ## Submission Instructions
 You are not required to submit anything via GitHub, but you are responsbile for ensuring your grade is recorded correctly. Check your grade in Canvas after completing this assignment.

--- a/P1-Assignment_Repository_Setup/README.md
+++ b/P1-Assignment_Repository_Setup/README.md
@@ -1,6 +1,6 @@
 # Liftoff Assignments
 
-This repository is the base repo for all assignments in LaunchCode's [Liftoff](http://education.launchcode.org/liftoff/) course.
+This repository is the base repo for all assignments in LaunchCode's [Liftoff](http:/education.launchcode.org/liftoff-OLD/) course.
 
 ## Getting Started
 

--- a/P2-Project_Outline/README.md
+++ b/P2-Project_Outline/README.md
@@ -2,7 +2,7 @@
 For this assignment, you will submit a high-level outline of your project. This can, and likely will, change over time. In particular, your mentor will provide feedback and direction and feedback to help sharpen your ideas. So don't worry if you feel unsure about some aspects of the outline, or if you have to change some things later.
 
 ## Assignment Description
-[Project Outline Assignment](https://education.launchcode.org/liftoff/assignments/project-outline/)
+[Project Outline Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/project-outline/)
 
 ## Submission Instructions
 

--- a/P3-Project_Planning/README.md
+++ b/P3-Project_Planning/README.md
@@ -2,7 +2,7 @@
 For this assignment, you'll create some initial plans for your project.
 
 ## Assignment Description
-[Project Planning Assignment](https://education.launchcode.org/liftoff/assignments/planning/)
+[Project Planning Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/planning/)
 
 ## Submission Instructions
 

--- a/P4-Project_Setup/README.md
+++ b/P4-Project_Setup/README.md
@@ -2,7 +2,7 @@
 This assignment will get you set up and rolling with a basic project. By the end, you will have a GitHub repo that contains a working application.
 
 ## Assignment Description
-[Project Setup Assignment](https://education.launchcode.org/liftoff/assignments/project-setup/)
+[Project Setup Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/project-setup/)
 
 ## Submission Instructions
 

--- a/P5-Project_Review/README.md
+++ b/P5-Project_Review/README.md
@@ -5,7 +5,7 @@ If you have made progress, and you engage with your mentor you will be marked as
 
 ## Assignment Description
 
-[Project Review Assignment](https://education.launchcode.org/liftoff/assignments/project-review/)
+[Project Review Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/project-review/)
 
 ## Submission Instructions
 Your mentor will update your grade after your review. If your grade is missing, check in with your Mentor.

--- a/P6-Project_Presentation/README.md
+++ b/P6-Project_Presentation/README.md
@@ -2,7 +2,7 @@
 We want to you to create a set of presentation slides summarizing your project.
 
 ## Assignment Description
-[Project Presentation Assignment](https://education.launchcode.org/liftoff/assignments/project-presentation/)
+[Project Presentation Assignment](https:/education.launchcode.org/liftoff-OLD/assignments/project-presentation/)
 
 ## Submission Instructions
 


### PR DESCRIPTION
In switching the material to a new site, the old pages are now inaccessible via the markdown file links.